### PR TITLE
Add dependency github.com/resend/resend-go/v2 and email notification for fatal logs

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,5 @@
 POSTGRESQL_URL=postgres://postgres:password@localhost:5432/log?sslmode=disable
 BUNDEBUG=2
 APP_ENVIRONMENT=DEBUG
+RESEND_API_KEY=1234567890
+DEV_EMAIL=email@abc.com

--- a/backend/config/env.go
+++ b/backend/config/env.go
@@ -39,3 +39,5 @@ var AppIsDebug = AppEnv == AppEnvDebug
 var AppName = GetEnv("APP_NAME", "service.log-management")
 var AppPort = GetEnv("APP_PORT", "8080")
 var DB_URL = GetEnv("POSTGRESQL_URL", "postgres://postgres:password@localhost:5432/log?sslmode=disable")
+var RESEND_API_KEY = MustGetEnv("RESEND_API_KEY")
+var DEV_EMAIL = MustGetEnv("DEV_EMAIL")

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -6,6 +6,7 @@ require github.com/rs/zerolog v1.31.0
 
 require (
 	github.com/fatih/color v1.15.0 // indirect
+	github.com/resend/resend-go/v2 v2.4.0 // indirect
 	github.com/rs/xid v1.5.0 // indirect
 	golang.org/x/crypto v0.13.0 // indirect
 	mellium.im/sasl v0.3.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -19,6 +19,8 @@ github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNs
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/resend/resend-go/v2 v2.4.0 h1:yw517kpnmcEkJt/j5mTchJnqJ80Wr+mWEWoR0hQIUEA=
+github.com/resend/resend-go/v2 v2.4.0/go.mod h1:ihnxc7wPpSgans8RV8d8dIF4hYWVsqMK5KxXAr9LIos=
 github.com/rs/xid v1.5.0 h1:mKX4bl4iPYJtEIxp6CYiUuLQ/8DYMoz0PUdtGgMFRVc=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.31.0 h1:FcTR3NnLWW+NnTwwhFWiJSZr4ECLpqCm6QsEnyvbV4A=

--- a/backend/migrations/000001_initial.up.sql
+++ b/backend/migrations/000001_initial.up.sql
@@ -22,7 +22,6 @@ CREATE TABLE IF NOT EXISTS "logs" (
     "deleted_at" TIMESTAMPTZ,
     "metadata" JSONB NOT NULL DEFAULT '{}',
     "microservice_id" VARCHAR NOT NULL,
-    -- TODO: Add log level enum
     "log_level" VARCHAR NOT NULL,
     "message" VARCHAR NOT NULL,
     PRIMARY KEY ("id"),


### PR DESCRIPTION
This pull request adds the dependency github.com/resend/resend-go/v2 and implements email notification for fatal logs. It also includes the necessary environment variables for the functionality.