### PR TITLE
Add unit tests and test coverage

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -36,4 +36,4 @@ build:
 	docker build -t ${DOCKER_IMAGE} --network host --build-arg COMMIT .
 
 test:
-	go test ./... -count=2
+	go test -cover ./... -count=2

--- a/backend/domain/base_test.go
+++ b/backend/domain/base_test.go
@@ -1,0 +1,53 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBase(t *testing.T) {
+	base := Base{
+		ID:        "123",
+		CreatedBy: "SYSTEM",
+		UpdatedBy: "SYSTEM",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		DeletedAt: time.Now(),
+		Metadata:  map[string]string{},
+	}
+
+	// Test ID field
+	if base.ID != "123" {
+		t.Errorf("unexpected ID value: got %s, want %s", base.ID, "123")
+	}
+
+	// Test CreatedBy field
+	if base.CreatedBy != "SYSTEM" {
+		t.Errorf("unexpected CreatedBy value: got %s, want %s", base.CreatedBy, "SYSTEM")
+	}
+
+	// Test UpdatedBy field
+	if base.UpdatedBy != "SYSTEM" {
+		t.Errorf("unexpected UpdatedBy value: got %s, want %s", base.UpdatedBy, "SYSTEM")
+	}
+
+	// Test CreatedAt field
+	if base.CreatedAt.IsZero() {
+		t.Error("unexpected zero value for CreatedAt")
+	}
+
+	// Test UpdatedAt field
+	if base.UpdatedAt.IsZero() {
+		t.Error("unexpected zero value for UpdatedAt")
+	}
+
+	// Test DeletedAt field
+	if base.DeletedAt.IsZero() {
+		t.Error("unexpected zero value for DeletedAt")
+	}
+
+	// Test Metadata field
+	if base.Metadata == nil {
+		t.Error("unexpected nil value for Metadata")
+	}
+}

--- a/backend/handler/create_log_test.go
+++ b/backend/handler/create_log_test.go
@@ -1,0 +1,68 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"log-management/mocks"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestHandler_CreateLog(t *testing.T) {
+	handler := &Handler{
+		db: &mocks.MockDAO{},
+	}
+
+	// Create a new HTTP request with a sample log request
+	logReq := logRequest{
+		MicroserviceID: "123",
+		Level:          "info",
+		Message:        "Sample log message",
+	}
+	reqBody, _ := json.Marshal(logReq)
+	req, err := http.NewRequest("POST", "/log", bytes.NewBuffer(reqBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a response recorder to capture the response
+	rr := httptest.NewRecorder()
+
+	// Create a new router and register the handler
+	r := chi.NewRouter()
+	r.HandleFunc("/log", handler.CreateLog)
+
+	// Serve the request using the router
+	r.ServeHTTP(rr, req)
+
+	// Check the response status code
+	if status := rr.Code; status != http.StatusCreated {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusCreated)
+	}
+	
+	// Check the response body
+	var logResp LogResponse
+	err = json.Unmarshal(rr.Body.Bytes(), &logResp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Example assertions for checking the log response
+	expectedMicroserviceName := "Test Microservice"
+	expectedLevel := "info"
+	expectedMessage := "Sample log message"
+	if logResp.MicroserviceName != expectedMicroserviceName {
+		t.Errorf("handler returned unexpected microservice name: got %v want %v", logResp.MicroserviceName, expectedMicroserviceName)
+	}
+
+	if logResp.Level != expectedLevel {
+		t.Errorf("handler returned unexpected log level: got %v want %v", logResp.Level, expectedLevel)
+	}
+
+	if logResp.Message != expectedMessage {
+		t.Errorf("handler returned unexpected log message: got %v want %v", logResp.Message, expectedMessage)
+	}
+}

--- a/backend/handler/create_microservice_test.go
+++ b/backend/handler/create_microservice_test.go
@@ -1,0 +1,68 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"log-management/domain"
+	"log-management/mocks"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestHandler_CreateMicroservice(t *testing.T) {
+	handler := &Handler{
+		db: &mocks.MockDAO{},
+	}
+
+	// Create a sample request body
+	microserviceReq := microserviceRequest{
+		Name:        "Test Microservice",
+		Description: "Test Description",
+	}
+
+	reqBody, err := json.Marshal(microserviceReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a new HTTP request with the sample request body
+	req, err := http.NewRequest("POST", "/microservice", bytes.NewBuffer(reqBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a response recorder to capture the response
+	rr := httptest.NewRecorder()
+
+	// Create a new router and register the handler
+	r := chi.NewRouter()
+	r.HandleFunc("/microservice", handler.CreateMicroservice)
+
+	// Serve the request using the router
+	r.ServeHTTP(rr, req)
+
+	// Check the response status code
+	if status := rr.Code; status != http.StatusCreated {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusCreated)
+	}
+
+	// Check the response body
+	var microserviceRes domain.Microservice
+	err = json.Unmarshal(rr.Body.Bytes(), &microserviceRes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := microserviceReq.Name
+	if microserviceRes.Name != expected {
+		t.Errorf("handler returned unexpected name: got %v want %v", microserviceRes.Name, expected)
+	}
+
+	expected = microserviceReq.Description
+	if microserviceRes.Description != expected {
+		t.Errorf("handler returned unexpected description: got %v want %v", microserviceRes.Description, expected)
+	}
+}

--- a/backend/handler/get_log_test.go
+++ b/backend/handler/get_log_test.go
@@ -1,0 +1,66 @@
+package handler
+
+import (
+	"encoding/json"
+	"log-management/mocks"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestHandler_GetLog(t *testing.T) {
+	handler := &Handler{
+		db: &mocks.MockDAO{},
+	}
+
+	// Create a new HTTP request with a sample log ID
+	req, err := http.NewRequest("GET", "/log/123", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a response recorder to capture the response
+	rr := httptest.NewRecorder()
+
+	// Create a new router and register the handler
+	r := chi.NewRouter()
+	r.HandleFunc("/log/{id}", handler.GetLog)
+
+	// Serve the request using the router
+	r.ServeHTTP(rr, req)
+
+	// Check the response status code
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	// Check the response body
+	var logResp LogResponse
+	err = json.Unmarshal(rr.Body.Bytes(), &logResp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Example assertions for checking the log response
+	expectedID := "123"
+	expectedMicroserviceName := "Test Microservice"
+	expectedLevel := "info"
+	expectedMessage := "Sample log message"
+	if logResp.ID != expectedID {
+		t.Errorf("handler returned unexpected log ID: got %v want %v", logResp.ID, expectedID)
+	}
+
+	if logResp.MicroserviceName != expectedMicroserviceName {
+		t.Errorf("handler returned unexpected microservice name: got %v want %v", logResp.MicroserviceName, expectedMicroserviceName)
+	}
+
+	if logResp.Level != expectedLevel {
+		t.Errorf("handler returned unexpected log level: got %v want %v", logResp.Level, expectedLevel)
+	}
+
+	if logResp.Message != expectedMessage {
+		t.Errorf("handler returned unexpected log message: got %v want %v", logResp.Message, expectedMessage)
+	}
+}

--- a/backend/handler/get_microservice_test.go
+++ b/backend/handler/get_microservice_test.go
@@ -1,0 +1,53 @@
+package handler
+
+import (
+	"encoding/json"
+	"log-management/domain"
+	"log-management/mocks"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestHandler_GetMicroservice(t *testing.T) {
+	handler := &Handler{
+		db: &mocks.MockDAO{},
+	}
+
+	// Create a new HTTP request with a sample ID
+	req, err := http.NewRequest("GET", "/microservice/123", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a response recorder to capture the response
+	rr := httptest.NewRecorder()
+
+	// Create a new router and register the handler
+	r := chi.NewRouter()
+	r.HandleFunc("/microservice/{id}", handler.GetMicroservice)
+
+	// Serve the request using the router
+	r.ServeHTTP(rr, req)
+
+	// Check the response status code
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	// Check the response body
+	var microservice domain.Microservice
+	err = json.Unmarshal(rr.Body.Bytes(), &microservice)
+	if err != nil {
+		t.Errorf("error decoding response body: %v", err)
+	}
+
+	// Example assertion for checking the ID
+	expectedID := "123"
+	if microservice.ID != expectedID {
+		t.Errorf("handler returned unexpected ID: got %v want %v", microservice.ID, expectedID)
+	}
+
+}

--- a/backend/handler/list_logs_test.go
+++ b/backend/handler/list_logs_test.go
@@ -1,0 +1,88 @@
+package handler
+
+import (
+	"encoding/json"
+	"log-management/domain"
+	"log-management/mocks"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestHandler_ListLogs(t *testing.T) {
+	handler := &Handler{
+		db: &mocks.MockDAO{},
+	}
+
+	// Create a new HTTP request
+	req, err := http.NewRequest("GET", "/logs", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a response recorder to capture the response
+	rr := httptest.NewRecorder()
+
+	// Create a new router and register the handler
+	r := chi.NewRouter()
+	r.HandleFunc("/logs", handler.ListLogs)
+
+	// Serve the request using the router
+	r.ServeHTTP(rr, req)
+
+	// Check the response status code
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	// Check the response body
+	var logs []domain.Log
+	err = json.Unmarshal(rr.Body.Bytes(), &logs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Example assertions for checking the logs
+	expectedLogs := []domain.Log{
+		{
+			Base: domain.Base{
+				ID:        "123",
+				CreatedBy: "SYSTEM",
+				UpdatedBy: "SYSTEM",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+			MicroserviceID: "123",
+			LogLevel:       "info",
+			Message:        "Sample log message",
+		},
+		{
+			Base: domain.Base{
+				ID:        "456",
+				CreatedBy: "SYSTEM",
+				UpdatedBy: "SYSTEM",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+			MicroserviceID: "123",
+			LogLevel:       "info",
+			Message:        "Sample log message",
+		},
+	}
+	if len(logs) != len(expectedLogs) {
+		t.Errorf("handler returned unexpected number of logs: got %d want %d", len(logs), len(expectedLogs))
+	}
+
+	for i, log := range logs {
+		if log.ID != expectedLogs[i].ID {
+			t.Errorf("handler returned unexpected log ID at index %d: got %s want %s", i, log.ID, expectedLogs[i].ID)
+		}
+
+		if log.Message != expectedLogs[i].Message {
+			t.Errorf("handler returned unexpected log message at index %d: got %s want %s", i, log.Message, expectedLogs[i].Message)
+		}
+	}
+}

--- a/backend/handler/list_microservice_test.go
+++ b/backend/handler/list_microservice_test.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	"encoding/json"
+	"log-management/domain"
+	"log-management/mocks"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestHandler_ListMicroservices(t *testing.T) {
+	handler := &Handler{
+		db: &mocks.MockDAO{},
+	}
+
+	// Create a new HTTP request
+	req, err := http.NewRequest("GET", "/microservices", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a response recorder to capture the response
+	rr := httptest.NewRecorder()
+
+	// Create a new router and register the handler
+	r := chi.NewRouter()
+	r.HandleFunc("/microservices", handler.ListMicroservices)
+
+	// Serve the request using the router
+	r.ServeHTTP(rr, req)
+
+	// Check the response status code
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	// Check the response body
+	var microservices []domain.Microservice
+	err = json.Unmarshal(rr.Body.Bytes(), &microservices)
+	if err != nil {
+		t.Errorf("handler returned invalid JSON response: %v", err)
+	}
+
+	// Example assertion for checking the number of microservices
+	expectedNumMicroservices := 2
+	if len(microservices) != expectedNumMicroservices {
+		t.Errorf("handler returned unexpected number of microservices: got %v want %v", len(microservices), expectedNumMicroservices)
+	}
+}

--- a/backend/handler/ping_test.go
+++ b/backend/handler/ping_test.go
@@ -1,0 +1,34 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandler_Ping(t *testing.T) {
+	handler := &Handler{} // Create an instance of your handler
+
+	// Create a new HTTP request
+	req, err := http.NewRequest("GET", "/ping", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a response recorder to capture the response
+	rr := httptest.NewRecorder()
+
+	// Call the Ping handler function
+	handler.Ping(rr, req)
+
+	// Check the response status code
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	// Check the response body
+	expected := "pong"
+	if rr.Body.String() != expected {
+		t.Errorf("handler returned unexpected body: got %v want %v", rr.Body.String(), expected)
+	}
+}

--- a/backend/handler/update_log_test.go
+++ b/backend/handler/update_log_test.go
@@ -1,0 +1,62 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"log-management/mocks"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestHandler_UpdateLog(t *testing.T) {
+	handler := &Handler{
+		db: &mocks.MockDAO{},
+	}
+
+	// Create a new HTTP request with a sample update log request
+	updateLogReq := UpdateLogStruct{
+		ID:      "123",
+		Message: "Updated log message",
+	}
+	reqBody, _ := json.Marshal(updateLogReq)
+	req, err := http.NewRequest("PUT", "/log", bytes.NewBuffer(reqBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a response recorder to capture the response
+	rr := httptest.NewRecorder()
+
+	// Create a new router and register the handler
+	r := chi.NewRouter()
+	r.HandleFunc("/log", handler.UpdateLog)
+
+	// Serve the request using the router
+	r.ServeHTTP(rr, req)
+
+	// Check the response status code
+	if status := rr.Code; status != http.StatusCreated {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusCreated)
+	}
+
+	// Check the response body
+	var updatedLog UpdateLogStruct
+	err = json.Unmarshal(rr.Body.Bytes(), &updatedLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Example assertions for checking the updated log
+	expectedID := "123"
+	expectedMessage := "Updated log message"
+	if updatedLog.ID != expectedID {
+		t.Errorf("handler returned unexpected log ID: got %v want %v", updatedLog.ID, expectedID)
+	}
+
+	if updatedLog.Message != expectedMessage {
+		t.Errorf("handler returned unexpected log message: got %v want %v", updatedLog.Message, expectedMessage)
+	}
+}

--- a/backend/handler/update_microservice_test.go
+++ b/backend/handler/update_microservice_test.go
@@ -1,0 +1,69 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"log-management/domain"
+	"log-management/mocks"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestHandler_UpdateMicroservice(t *testing.T) {
+	handler := &Handler{
+		db: &mocks.MockDAO{},
+	}
+
+	// Create a sample request body
+	microserviceReq := UpdateMicroserviceStruct{
+		ID:          "sampleID",
+		Name:        "Sample Name",
+		Description: "Sample Description",
+	}
+	reqBody, err := json.Marshal(microserviceReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a new HTTP request with the sample request body
+	req, err := http.NewRequest("PUT", "/microservice", bytes.NewBuffer(reqBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a response recorder to capture the response
+	rr := httptest.NewRecorder()
+
+	// Create a new router and register the handler
+	r := chi.NewRouter()
+	r.HandleFunc("/microservice", handler.UpdateMicroservice)
+
+	// Serve the request using the router
+	r.ServeHTTP(rr, req)
+
+	// Check the response status code
+	if status := rr.Code; status != http.StatusCreated {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusCreated)
+	}
+
+	// Check the response body
+	var microserviceRes domain.Microservice
+	err = json.NewDecoder(rr.Body).Decode(&microserviceRes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Compare the response body with the expected values
+	if microserviceRes.ID != microserviceReq.ID {
+		t.Errorf("handler returned unexpected ID: got %v want %v", microserviceRes.ID, microserviceReq.ID)
+	}
+	if microserviceRes.Name != microserviceReq.Name {
+		t.Errorf("handler returned unexpected Name: got %v want %v", microserviceRes.Name, microserviceReq.Name)
+	}
+	if microserviceRes.Description != microserviceReq.Description {
+		t.Errorf("handler returned unexpected Description: got %v want %v", microserviceRes.Description, microserviceReq.Description)
+	}
+}

--- a/backend/mocks/dao.go
+++ b/backend/mocks/dao.go
@@ -1,0 +1,141 @@
+package mocks
+
+import (
+	"context"
+	"log-management/domain"
+
+	"time"
+)
+
+// MockDAO is a struct that implements the DAO interface for testing
+type MockDAO struct {
+	Microservices *domain.Microservice
+	Logs          *domain.Log
+}
+
+func (m *MockDAO) CreateMicroservice(ctx context.Context, microservice *domain.Microservice) (*domain.Microservice, error) {
+	microservice.CreatedBy = "SYSTEM"
+	microservice.UpdatedBy = "SYSTEM"
+
+	return microservice, nil
+}
+func (m *MockDAO) CreateLog(ctx context.Context, log *domain.Log) (*domain.Log, error) {
+	log.CreatedBy = "SYSTEM"
+	log.UpdatedBy = "SYSTEM"
+
+	return log, nil
+}
+
+func (m *MockDAO) GetMicroservice(ctx context.Context, id string) (*domain.Microservice, error) {
+	microservice := &domain.Microservice{
+		Base: domain.Base{
+			ID:        id,
+			CreatedBy: "SYSTEM",
+			UpdatedBy: "SYSTEM",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+		Name:        "Test Microservice",
+		Description: "Test Description",
+	}
+
+	return microservice, nil
+}
+func (m *MockDAO) GetLog(ctx context.Context, id string) (*domain.Log, error) {
+	log := &domain.Log{
+		Base: domain.Base{
+			ID:        id,
+			CreatedBy: "SYSTEM",
+			UpdatedBy: "SYSTEM",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+		MicroserviceID: "123",
+		LogLevel:       "info",
+		Message:        "Sample log message",
+	}
+
+	return log, nil
+}
+
+func (m *MockDAO) ListMicroservices(ctx context.Context) ([]*domain.Microservice, error) {
+	microservices := []*domain.Microservice{
+		{
+			Base: domain.Base{
+				ID:        "123",
+				CreatedBy: "SYSTEM",
+				UpdatedBy: "SYSTEM",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+			Name:        "TestMicroservice",
+			Description: "Test Description",
+		},
+		{
+			Base: domain.Base{
+				ID:        "456",
+				CreatedBy: "SYSTEM",
+				UpdatedBy: "SYSTEM",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+			Name:        "TestMicroservice2",
+			Description: "Test Description2",
+		},
+	}
+
+	return microservices, nil
+}
+func (m *MockDAO) ListLogs(ctx context.Context, microserviceID string) ([]*domain.Log, error) {
+	return []*domain.Log{m.Logs}, nil
+}
+func (m *MockDAO) ListAllLogs(ctx context.Context) ([]*domain.Log, error) {
+	logs := []*domain.Log{
+		{
+			Base: domain.Base{
+				ID:        "123",
+				CreatedBy: "SYSTEM",
+				UpdatedBy: "SYSTEM",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+			MicroserviceID: "123",
+			LogLevel:       "info",
+			Message:        "Sample log message",
+		},
+		{
+			Base: domain.Base{
+				ID:        "456",
+				CreatedBy: "SYSTEM",
+				UpdatedBy: "SYSTEM",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+			MicroserviceID: "123",
+			LogLevel:       "info",
+			Message:        "Sample log message",
+		},
+	}
+
+	return logs, nil
+}
+
+func (m *MockDAO) UpdateMicroservice(ctx context.Context, microservice *domain.Microservice) (*domain.Microservice, error) {
+	microservice.UpdatedAt = time.Now()
+	microservice.UpdatedBy = "SYSTEM"
+
+	return microservice, nil
+}
+func (m *MockDAO) UpdateLog(ctx context.Context, log *domain.Log) (*domain.Log, error) {
+	log.UpdatedAt = time.Now()
+	log.UpdatedBy = "SYSTEM"
+
+	return log, nil
+}
+
+func (m *MockDAO) DeleteMicroservice(ctx context.Context, id string) error {
+	return nil
+}
+func (m *MockDAO) DeleteLog(ctx context.Context, id string) error {
+	return nil
+}

--- a/backend/utils/utils_test.go
+++ b/backend/utils/utils_test.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGenerateHumanID(t *testing.T) {
+	// Test case 1: Empty prefix
+	expectedPrefix := "LGM"
+	expectedNow := time.Now()
+	expectedNs := expectedNow.UnixMilli() % millisecondsPerSecond
+
+	expectedID := fmt.Sprintf("%s%d-%03d-%02d%02d%02d%03d", strings.ToUpper(expectedPrefix), expectedNow.Year()-2000, expectedNow.YearDay(), expectedNow.Hour(), expectedNow.Minute(), expectedNow.Second(), expectedNs)
+
+	result := GenerateHumanID("")
+	if result != expectedID {
+		t.Errorf("GenerateHumanID with empty prefix returned unexpected ID: got %v, want %v", result, expectedID)
+	}
+
+	// Test case 2: Non-empty prefix
+	customPrefix := "ABC"
+	expectedID = fmt.Sprintf("%s%d-%03d-%02d%02d%02d%03d", strings.ToUpper(customPrefix), expectedNow.Year()-2000, expectedNow.YearDay(), expectedNow.Hour(), expectedNow.Minute(), expectedNow.Second(), expectedNs)
+
+	result = GenerateHumanID(customPrefix)
+	if result != expectedID {
+		t.Errorf("GenerateHumanID with custom prefix returned unexpected ID: got %v, want %v", result, expectedID)
+	}
+}


### PR DESCRIPTION
This pull request adds unit tests and test coverage for various components of the application. It includes tests for handler functions, domain structs, and utility functions. Additionally, test coverage is improved by updating the test command in the Makefile to include the -cover flag.